### PR TITLE
Standardize configuration with the Sauce Launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,7 @@ module.exports = function(karma) {
 
   var webdriverConfig = {
     url: 'ondemand.saucelabs.com',
-    port: 80,
-    user: 'username',
-    key: 'saucelabs-api-key'
+    port: 80
   }
 
 
@@ -32,12 +30,10 @@ module.exports = function(karma) {
         'IE7': {
           base: 'WebDriver',
 		  config: webdriverConfig,
-		  spec: {
-			browserName: 'internet explorer',
-			platform: 'Windows XP',
-			version: '7',
-			name: 'Karma'
-		  }
+		  browserName: 'internet explorer',
+		  platform: 'Windows XP',
+		  version: '7',
+		  name: 'Karma'
 	    }
       },	  
 

--- a/index.js
+++ b/index.js
@@ -2,10 +2,23 @@ var fs = require('fs');
 var wd = require('wd');
 
 var WebDriverInstance = function (baseBrowserDecorator, args) {
-  var config = args.config;
-  var spec = args.spec;
+  var config = args.config || {
+    url: '127.0.0.1',
+    port: 4444
+  };
+  var spec = {
+    browserName: args.browserName,
+    version: args.version || '',
+    platform: args.platform || 'ANY',
+    tags: args.tags || [],
+    name: args.testName || 'Karma test'
+  };
   var self = this;
+
   baseBrowserDecorator(this);
+
+  this.name = spec.browserName + ' via Remote WebDriver';
+
 
   this.kill = function(callback) {
     self.browser.quit(function() {
@@ -15,7 +28,7 @@ var WebDriverInstance = function (baseBrowserDecorator, args) {
   }
 
   this._start = function (url) {
-    self.browser = wd.remote(config.url, config.port, config.user, config.key);
+    self.browser = wd.remote(config.url, config.port);
     self.browser.init(spec, function () {
       self.browser.get(url);
     });


### PR DESCRIPTION
This launcher should be interchangeable with the Sauce launcher. Refactored how users specify the Web Browser to match the syntax of he Sauce launcher. 

Users don't now have to specify the location and port of the Selenium Grid 2, a sensible default will be used.
