### PR TITLE
Use kill event instead overriding the .kill()

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,13 +19,12 @@ var WebDriverInstance = function (baseBrowserDecorator, args) {
 
   this.name = spec.browserName + ' via Remote WebDriver';
 
-
-  this.kill = function(callback) {
+  this.on('kill', function(callback) {
     self.browser.quit(function() {
       console.log('Killed ' + spec.name + '.');
       callback();
     });
-  }
+  });
 
   this._start = function (url) {
     self.browser = wd.remote(config);

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "wd": "0.2.8"
   },
   "peerDependencies": {
-    "karma": ">=0.9"
+    "karma": ">=0.12"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
Hi,
After Karma#11.11 ([e6f36ca](https://github.com/karma-runner/karma/commit/e6f36cacddcdae0d5626cbbe78dbf6720b0626af)) the .kill() metdod of launcher must return promise, otherwise the attempt to kill browser crashes on [this step](https://github.com/karma-runner/karma/blob/master/lib/launcher.js#L142) with 

```
TypeError: Cannot call method 'then' of undefined
```

We can use asyc [kill-event](https://github.com/karma-runner/karma/blob/master/lib/launchers/base.js#L50) to kill the browser instead of overriding .kill() method.
