### PR TITLE
Fix karma hanging after execution

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-var fs = require('fs');
 var wd = require('wd');
 
 var WebDriverInstance = function (baseBrowserDecorator, args, logger) {


### PR DESCRIPTION
While trying to use this launcher to execute tests on browsers from a Selenium Grid, I noticed that I had intermittent errors from the grid (browser timeouts, or "Failed to navigate" errors). In those cases, Karma would hang just after this launcher printed `Killed Karma test`.

These commits change the WD.js invocation style, and solve the issue. Besides, I made sure that the (already existing) Launcher retry mechanism is actually triggered in case of timeouts.
