### PR TITLE
Fix: correct methods overriding

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
-var fs = require('fs');
 var wd = require('wd');
 
-var WebDriverInstance = function (baseBrowserDecorator, args) {
+var WebDriverInstance = function (baseBrowserDecorator, args, logger) {
+  var log = logger.create('WebDriver');
+
   var config = args.config || {
     hostname: '127.0.0.1',
     port: 4444
@@ -19,19 +20,24 @@ var WebDriverInstance = function (baseBrowserDecorator, args) {
 
   this.name = spec.browserName + ' via Remote WebDriver';
 
-  this.on('kill', function(callback) {
-    self.browser.quit(function() {
-      console.log('Killed ' + spec.name + '.');
-      callback();
-    });
-  });
+  this._start = function(url) {
+    self.browser = wd.remote(config, 'promiseChain');
+    self.browser.init(spec)
+        .get(url)
+        .done();
 
-  this._start = function (url) {
-    self.browser = wd.remote(config);
-    self.browser.init(spec, function () {
-      self.browser.get(url);
-    });
+    self._process = {
+      kill: function() {
+        self.browser.quit(function() {
+          log.info('Killed ' + spec.name + '.');
+          self._onProcessExit(self.error ? -1 : 0, self.error);
+        });
+      }
+    };
   };
+
+  // We can't really force browser to quit so just avoid warning about SIGKILL
+  this._onKillTimeout = function(){};
 };
 
 WebDriverInstance.prototype = {
@@ -45,7 +51,7 @@ WebDriverInstance.prototype = {
   ENV_CMD: 'WEBDRIVER_BIN'
 };
 
-WebDriverInstance.$inject = ['baseBrowserDecorator', 'args'];
+WebDriverInstance.$inject = ['baseBrowserDecorator', 'args', 'logger'];
 
 // PUBLISH DI MODULE
 module.exports = {


### PR DESCRIPTION
Current implementation replaces `ProcessLauncher._start` method, but instead of replacing any method dealing with kill it just adds  new listener for `kill` event which just calls callback.
As a result:
- `BaseLauncher._done` method never called and so no event `done` emitted and karma process hangs
- callback called twice:
  - first time from `ProcessLauncher`'s kill listener without any error
  - second time from `WebDriverInstance`'s kill listener
- nobody removes tmp dir created by `ProcessLauncher`'s start listener

To fix this we shouldn't add any new listener but override any methods called from `ProcessLauncher`'s start/kill listeners:
- `_start`
- `_process.kill`
- `_onKillTimeout`
