### PR TITLE
Allow for the host to run tests against to be passed in via karmaHost property

### DIFF
--- a/examples/sauceLabs/karma.conf.js
+++ b/examples/sauceLabs/karma.conf.js
@@ -5,7 +5,7 @@ module.exports = function (karma) {
     port: 80,
     user: 'USERNAME',
     pwd: 'APIKEY'
-  }
+  };
 
   config.set({
     basePath: './',
@@ -26,4 +26,4 @@ module.exports = function (karma) {
     ],
     singleRun: true
   });
-}
+};

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ var WebDriverInstance = function (baseBrowserDecorator, args) {
   this._start = function (url) {
     self.browser = wd.remote(config);
     self.browser.init(spec, function () {
-      self.browser.get(url);
+      self.browser.get(url.replace(/(https{0,1}):\/\/localhost/, config.karmaHost ? '$1://' + config.karmaHost : '$1://localhost'));
     });
   };
 };


### PR DESCRIPTION
I have found a need to be able to pass a host which webdriver test instances should use to run their tests against.

Being able to alter the host on the webdriver launcher means that tests which run locally can still utilize the default host (localhost) and hence be less likely to have proxy issues.
