### PR TITLE
Added ability to define additional capabilities when initializing WebDriver connection

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,34 +1,37 @@
 var fs = require('fs');
 var wd = require('wd');
+var _ = {
+  assign: require('lodash.assign')
+};
 
 var WebDriverInstance = function (baseBrowserDecorator, args) {
   var config = args.config || {
     hostname: '127.0.0.1',
     port: 4444
   };
-  var spec = {
+  var desiredCapabilities = _.assign({
     browserName: args.browserName,
     version: args.version || '',
     platform: args.platform || 'ANY',
     tags: args.tags || [],
     name: args.testName || 'Karma test'
-  };
+  }, args.additionalCapabilities);
   var self = this;
 
   baseBrowserDecorator(this);
 
-  this.name = spec.browserName + ' via Remote WebDriver';
+  this.name = desiredCapabilities.browserName + ' via Remote WebDriver';
 
   this.on('kill', function(callback) {
     self.browser.quit(function() {
-      console.log('Killed ' + spec.name + '.');
+      console.log('Killed ' + desiredCapabilities.name + '.');
       callback();
     });
   });
 
   this._start = function (url) {
     self.browser = wd.remote(config);
-    self.browser.init(spec, function () {
+    self.browser.init(desiredCapabilities, function () {
       self.browser.get(url);
     });
   };

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "persidskiy <persidskiy@yandex-team.ru>"
   ],
   "dependencies": {
+    "lodash.assign": "^2.4.1",
     "wd": "0.2.8"
   },
   "peerDependencies": {


### PR DESCRIPTION
I needed the ability to add additional capabilities to the WebDriver session I'm initiating. This pull request will allow for any number of variations to be included. In particular my use case required me to pass along the options:

```
chromeOptions: {
  args: ['--no-sandbox']
}
```
