### PR TITLE
Imitate some activity to avoid disconnect from selenium by timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@ module.exports = function(karma) {
       customLaunchers: {
         'IE7': {
           base: 'WebDriver',
-		  config: webdriverConfig,
-		  browserName: 'internet explorer',
-		  platform: 'Windows XP',
-		  version: '10',
-		  'x-ua-compatible': 'IE=EmulateIE7',
-		  name: 'Karma',
+          config: webdriverConfig,
+          browserName: 'internet explorer',
+          platform: 'Windows XP',
+          version: '10',
+          'x-ua-compatible': 'IE=EmulateIE7',
+          name: 'Karma',
           pseudoActivityInterval: 30000
-	    }
+        }
       },
 
       browsers: ['IE7'],

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ module.exports = function(karma) {
     config.set({
 
       ...
-	  
+
       customLaunchers: {
         'IE7': {
           base: 'WebDriver',
@@ -36,9 +36,10 @@ module.exports = function(karma) {
 		  platform: 'Windows XP',
 		  version: '10',
 		  'x-ua-compatible': 'IE=EmulateIE7',
-		  name: 'Karma'
+		  name: 'Karma',
+          pseudoActivityInterval: 30000
 	    }
-      },	  
+      },
 
       browsers: ['IE7'],
 
@@ -49,3 +50,7 @@ module.exports = function(karma) {
 
 ```
 
+### pseudoActivityInterval
+Interval in ms to do some activity to avoid killing session by timeout.
+
+If not set or set to `0` - no activity will be performed.

--- a/index.js
+++ b/index.js
@@ -79,13 +79,20 @@ var WebDriverInstance = function (baseBrowserDecorator, args, logger) {
     log.debug('WebDriver config: ' + JSON.stringify(config));
     log.debug('Browser capabilities: ' + JSON.stringify(spec));
 
-    self.browser = wd.remote(config, 'promiseChain');
-    self.browser.init(spec)
+    self.browser = wd.remote(config, 'promiseChain').init(spec);
+
+    var interval = args.pseudoActivityInterval && setInterval(function() {
+      log.debug('Imitate activity');
+      self.browser.title();
+    }, args.pseudoActivityInterval);
+
+    self.browser
         .get(url)
         .done();
 
     self._process = {
       kill: function() {
+        interval && clearInterval(interval);
         self.browser.quit(function() {
           log.info('Killed ' + spec.testName + '.');
           self._onProcessExit(self.error ? -1 : 0, self.error);


### PR DESCRIPTION
In case of large amount of tests (800+) and slow browser (ie8) tests can run for a relatively long time (70-80 seconds). There is no activity until tests finish, and Selenium kills session by timeout (60 seconds by default).
This patch just periodically requests page title thus imitating activity.