### PR TITLE
updated wd dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,10 +38,10 @@
     "wd": "~0.3.11"
   },
   "devDependencies": {
-    "grunt": "~0.4.1",
-    "grunt-bump": "~0.0.7",
+    "grunt": "~1.0.1",
+    "grunt-bump": "~0.8.0",
     "grunt-npm": "~0.0.2",
-    "grunt-auto-release": "~0.0.2"
+    "grunt-auto-release": "~0.0.7"
   },
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "Enrique Paredes <enrique@iknite.com>"
   ],
   "dependencies": {
-    "wd": "~0.3.11"
+    "wd": "^1.0.0"
   },
   "devDependencies": {
     "grunt": "~1.0.1",


### PR DESCRIPTION
Seems to work fine in my projects (e.g. tested with @mercateo/ws).

This will update wd and we will get rid of npm warnings (especially when https://github.com/admc/wd/pull/457 is merged and released).