### PR TITLE
Expose WebDriver spec on Karma Browser instance

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,6 +47,7 @@ var WebDriverInstance = function (baseBrowserDecorator, args, logger) {
   baseBrowserDecorator(this);
 
   this.name = spec.browserName + ' via Remote WebDriver';
+  this.spec = spec;
 
   // Handle x-ua-compatible option same as karma-ie-launcher(copy&paste):
   //


### PR DESCRIPTION
This will allow us to create a Karma plugin to do WebDriver-based screenshots from our tests.